### PR TITLE
Add selected layers state to URL hash

### DIFF
--- a/src/loaders/loadGeoJsonFeatureCollections.js
+++ b/src/loaders/loadGeoJsonFeatureCollections.js
@@ -17,7 +17,7 @@ export const loadGeoJsonFeatureCollections = async (map, styleFunction, groupByP
     const geojsonLayer = L.geoJSON(geojsonData, {
       filter: filterByProperty(groupByProperty, value),
       style: styleFunction(value),
-    }).addTo(map);
+    });
 
     map.groups[value] = geojsonLayer;
   });


### PR DESCRIPTION
It would be nice to be able to share links and persist map state in the URL.

Currently the position and zoom level are persisted but not layers, selection, etc.

As a first pass and first contribution, I thought it might be nice to add the currently selected layers to the URL hash.

Placement,Placement_map layers are always added back on as default. I didn't want to change this behaviour without discussion

Using a schema of the style:
```
http://localhost:3000/#16.0000/57.6243/14.9257/layers:Placement,Placement_map,Aftermath22,Aftermath23
```

Am following [leaflet-hash-plus's](https://github.com/gregrobson/leaflet-hash-plus#overview) suggested convention for hash metadata and partially followed their [reference implementation](https://github.com/gregrobson/leaflet-hash-plus/blob/main/docs/demo.html#L70)

![](https://github.com/theborderland/map/assets/1245553/7e4e31ef-0377-4fb3-864f-3a1db607b1cc)
